### PR TITLE
pisr param override

### DIFF
--- a/R/tool-overrides.R
+++ b/R/tool-overrides.R
@@ -60,6 +60,18 @@ create_tool_overrides <- function(tool_name, params) {
       params$radius_max$identifier <- "RADIUS_MAX"
       params$radius_max$default <- 100
     }
+  } else if (tool_name == "potential_incoming_solar_radiation") {
+    if (!"hour_range_min" %in% names(params)) {
+      # rename hour_range to hour_range_min
+      names(params)[names(params) == "hour_range"] <- "hour_range_min"
+      params$hour_range_min$alias <- "hour_range_min"
+      params$hour_range_min$identifier <- "HOUR_RANGE_MIN"
+      
+      # add a new hour_range_max parameter
+      params$hour_range_max <- params$hour_range_min
+      params$hour_range_max$alias <- "hour_range_max"
+      params$hour_range_max$identifier <- "HOUR_RANGE_MAX"
+    }
   }
 
   params


### PR DESCRIPTION
Adds a parameter override for the "Potential Incoming Solar Radiation" tool to properly define the hour range values within the function. I have tested this and can confirm that it works as intended (Windows 11, R 4.3.3, SAGA GIS 9.3.1). Observing the help files for this SAGA GIS function as far back as I can find confirms that the altered argument names are the same across all versions of SAGA GIS, specifically:

- `HOUR_RANGE_MIN`, and
- `HOUR_RANGE_MAX`

Merging this PR would allow for closing of [this issue.](https://github.com/stevenpawley/Rsagacmd/issues/30)