### PR TITLE
add saga-gis path setting in r

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Description: Provides an R scripting interface to the open-source 'SAGA-GIS'
 License: GPL-3
 Encoding: UTF-8
 SystemRequirements: SAGA-GIS (>= 2.3.1)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Depends:
     R (>= 2.10)
 Imports:

--- a/R/search-saga.R
+++ b/R/search-saga.R
@@ -24,76 +24,79 @@
 #'
 #' @export
 search_saga <- function() {
-  # check to see if saga_cmd is recognized (i.e. has been added to path)
-  saga_cmd <- if (nchar(Sys.which(names = "saga_cmd")) > 0) "saga_cmd" else NULL
+  if (!is.null(getOption("saga_cmd"))){
+    return(getOption("saga_cmd"))
+  } else {
+    saga_cmd <- if (nchar(Sys.which(names = "saga_cmd")) > 0) "saga_cmd" else NULL
 
-  if (is.null(saga_cmd)) {
+    if (is.null(saga_cmd)) {
 
-    # define search paths
-    if (Sys.info()["sysname"] == "Windows") {
-      search_paths <- c(
-        "C:/Program Files/SAGA-GIS",
-        "C:/Program Files (x86)/SAGA-GIS",
-        "C:/SAGA-GIS",
-        "C:/OSGeo4W",
-        "C:/OSGeo4W64"
-      )
-      saga_executable <- "saga_cmd.exe"
+      # define search paths
+      if (Sys.info()["sysname"] == "Windows") {
+        search_paths <- c(
+          "C:/Program Files/SAGA-GIS",
+          "C:/Program Files (x86)/SAGA-GIS",
+          "C:/SAGA-GIS",
+          "C:/OSGeo4W",
+          "C:/OSGeo4W64"
+        )
+        saga_executable <- "saga_cmd.exe"
       
-    } else if (Sys.info()["sysname"] == "Linux") {
-      search_paths <- c("/usr")
-      saga_executable <- "saga_cmd$"
+      } else if (Sys.info()["sysname"] == "Linux") {
+        search_paths <- c("/usr")
+        saga_executable <- "saga_cmd$"
       
-    } else if (Sys.info()["sysname"] == "Darwin") {
-      search_paths <- c(
-        "/Applications/SAGA.app/Contents/MacOS",
-        "/usr/local/bin",
-        "/Applications/QGIS.app/Contents/MacOS/bin"
-      )
+      } else if (Sys.info()["sysname"] == "Darwin") {
+        search_paths <- c(
+          "/Applications/SAGA.app/Contents/MacOS",
+          "/usr/local/bin",
+          "/Applications/QGIS.app/Contents/MacOS/bin"
+        )
 
-      saga_executable <- "^saga_cmd$"
+        saga_executable <- "^saga_cmd$"
+      }
+
+      # search for saga_cmd executable
+      saga_cmd <- c()
+      for (f in search_paths) {
+        saga_cmd <- c(saga_cmd, list.files(
+          path = f,
+          pattern = saga_executable,
+          recursive = TRUE,
+          full.names = TRUE
+        ))
+      }
     }
 
-    # search for saga_cmd executable
-    saga_cmd <- c()
-    for (f in search_paths) {
-      saga_cmd <- c(saga_cmd, list.files(
-        path = f,
-        pattern = saga_executable,
-        recursive = TRUE,
-        full.names = TRUE
+    # error is saga_cmd not found
+    if (length(saga_cmd) == 0) {
+      rlang::abort(
+        paste(
+          "SAGA-GIS installation not found. Need to supply a valid path",
+          "to the saga_cmd executable"
+        )
+      )
+
+      return(NULL)
+
+      # automatically use newest version if multiple installations are found
+    } else if (length(saga_cmd) > 1) {
+      message("Multiple installations of SAGA-GIS were found at:")
+      message(paste(saga_cmd, collapse = "\n"))
+      message(paste(
+        "Choosing newest version. Manually specify the location when",
+        "calling saga_gis() to use an older version"
       ))
-    }
-  }
 
-  # error is saga_cmd not found
-  if (length(saga_cmd) == 0) {
-    rlang::abort(
-      paste(
-        "SAGA-GIS installation not found. Need to supply a valid path",
-        "to the saga_cmd executable"
-      )
-    )
+      saga_vers <- list()
 
-    return(NULL)
+      for (saga_inst in saga_cmd) {
+        saga_vers <- append(saga_vers, saga_version(saga_inst))
+      }
 
-    # automatically use newest version if multiple installations are found
-  } else if (length(saga_cmd) > 1) {
-    message("Multiple installations of SAGA-GIS were found at:")
-    message(paste(saga_cmd, collapse = "\n"))
-    message(paste(
-      "Choosing newest version. Manually specify the location when",
-      "calling saga_gis() to use an older version"
-    ))
-
-    saga_vers <- list()
-
-    for (saga_inst in saga_cmd) {
-      saga_vers <- append(saga_vers, saga_version(saga_inst))
+      saga_cmd <- saga_cmd[which(saga_vers == max(saga_vers))]
     }
 
-    saga_cmd <- saga_cmd[which(saga_vers == max(saga_vers))]
+    return(saga_cmd)
   }
-
-  return(saga_cmd)
 }

--- a/man/Rsagacmd.Rd
+++ b/man/Rsagacmd.Rd
@@ -2,8 +2,8 @@
 % Please edit documentation in R/Rsagacmd-package.R
 \docType{package}
 \name{Rsagacmd}
-\alias{Rsagacmd}
 \alias{Rsagacmd-package}
+\alias{Rsagacmd}
 \title{Rsagacmd: Linking R with the open-source SAGA-GIS software.}
 \description{
 \pkg{Rsagacmd} provides an R scripting interface to the open-source System


### PR DESCRIPTION
- First use the `getOption("saga_cmd")` in `search_saga()` to simplify the configuration of the saga_cmd environment variable on the windows platform.
- Use roxygen2 7.3.2