### PR TITLE
R/saga-gis.R: Read html docs as utf-8

### DIFF
--- a/R/saga-gis.R
+++ b/R/saga-gis.R
@@ -80,7 +80,8 @@ saga_env <-
       tool_names_file <- tool_files[which.min(nchar(tool_files))]
       
       # get library description
-      lib_html <- rvest::read_html(paste(libdir, tool_names_file, sep = "/"))
+      lib_html <- rvest::read_html(paste(libdir, tool_names_file, sep = "/"),
+                                   encoding = "UTF-8")
       
       lib_description_html <- rvest::html_elements(
         lib_html,
@@ -99,7 +100,8 @@ saga_env <-
       for (tool in tool_files) {
         tryCatch(
           expr = {
-            html <- rvest::read_html(paste(libdir, tool, sep = "/"))
+            html <- rvest::read_html(paste(libdir, tool, sep = "/"),
+                                     encoding = "UTF-8")
             options <- rvest::html_table(html, trim = TRUE)
 
             description_html <-


### PR DESCRIPTION
Under FreeBSD with a fully UTF-8 encoded system, SAGA-GIS tool descriptions generated in HTML format using 'saga_cmd --create-docs' are not read in correctly.

In Rsagacmd, this can be tested with SAGA GIS v9.10 or higher, e.g., with 'saga$io_webservices'. The tool 'dgm1_thüringen' with umlauts is included there. The tool name is read incorrectly by rvest::read_html, although UTF-8 or UTF-16 should actually be used there by default.

This patch forces the reading as UTF-8 encoded, as the xml routines in Rsagacmd also do.